### PR TITLE
fix: Provide the source URL in completion callbacks

### DIFF
--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -45,7 +45,7 @@ struct ContentView: View {
         .sheet(item: $sheet) { sheet in
             switch sheet {
             case .index:
-                SoftwareIndexView { url in
+                SoftwareIndexView { item in
                     self.sheet = nil
                 }
             }

--- a/Sources/PsionSoftwareIndex/Model/LibraryModel.swift
+++ b/Sources/PsionSoftwareIndex/Model/LibraryModel.swift
@@ -25,7 +25,7 @@ import SwiftUI
 protocol LibraryModelDelegate: AnyObject {
 
     @MainActor func libraryModelDidCancel(libraryModel: LibraryModel)
-    @MainActor func libraryModel(libraryModel: LibraryModel, didSelectURL url: URL)
+    @MainActor func libraryModel(libraryModel: LibraryModel, didSelectItem item: SoftwareIndexView.Item)
 
 }
 
@@ -128,8 +128,9 @@ protocol LibraryModelDelegate: AnyObject {
             return
         }
         let (url, _) = try await URLSession.shared.download(from: downloadURL)
+        let item = SoftwareIndexView.Item(sourceURL: downloadURL, url: url)
         await MainActor.run {
-            self.delegate?.libraryModel(libraryModel: self, didSelectURL: url)
+            self.delegate?.libraryModel(libraryModel: self, didSelectItem: item)
         }
     }
 

--- a/Sources/PsionSoftwareIndex/View Controllers/PsionSoftwareIndexViewController.swift
+++ b/Sources/PsionSoftwareIndex/View Controllers/PsionSoftwareIndexViewController.swift
@@ -27,7 +27,7 @@ public protocol PsionSoftwareIndexViewControllerDelegate: AnyObject {
 
     func psionSoftwareIndexViewCntrollerDidCancel(psionSoftwareIndexViewController: PsionSoftwareIndexViewController)
     func psionSoftwareIndexViewController(psionSoftwareIndexViewController: PsionSoftwareIndexViewController,
-                                          didSelectURL url: URL)
+                                          didSelectItem item: SoftwareIndexView.Item)
 
 }
 
@@ -55,8 +55,8 @@ extension PsionSoftwareIndexViewController: LibraryModelDelegate {
         delegate?.psionSoftwareIndexViewCntrollerDidCancel(psionSoftwareIndexViewController: self)
     }
 
-    func libraryModel(libraryModel: LibraryModel, didSelectURL url: URL) {
-        delegate?.psionSoftwareIndexViewController(psionSoftwareIndexViewController: self, didSelectURL: url)
+    func libraryModel(libraryModel: LibraryModel, didSelectItem item: SoftwareIndexView.Item) {
+        delegate?.psionSoftwareIndexViewController(psionSoftwareIndexViewController: self, didSelectItem: item)
     }
 
 }

--- a/Sources/PsionSoftwareIndex/Views/ProgramsView.swift
+++ b/Sources/PsionSoftwareIndex/Views/ProgramsView.swift
@@ -50,6 +50,7 @@ struct ProgramsView: View {
                 Button("Cancel") {
                     dismiss()
                 }
+                .keyboardShortcut(.cancelAction)
             }
         }
         .onAppear {

--- a/Sources/PsionSoftwareIndex/Views/SoftwareIndexView.swift
+++ b/Sources/PsionSoftwareIndex/Views/SoftwareIndexView.swift
@@ -22,9 +22,9 @@ import SwiftUI
 
 class LibraryModelBlockDelegate: LibraryModelDelegate {
 
-    let complete: (URL?) -> Void
+    let complete: (SoftwareIndexView.Item?) -> Void
 
-    init(complete: @escaping (URL?) -> Void) {
+    init(complete: @escaping (SoftwareIndexView.Item?) -> Void) {
         self.complete = complete
     }
 
@@ -32,14 +32,21 @@ class LibraryModelBlockDelegate: LibraryModelDelegate {
         self.complete(nil)
     }
 
-    func libraryModel(libraryModel: LibraryModel, didSelectURL url: URL) {
-        self.complete(url)
+    func libraryModel(libraryModel: LibraryModel, didSelectItem item: SoftwareIndexView.Item) {
+        self.complete(item)
     }
 
 }
 
 // TODO: Rename?
 public struct SoftwareIndexView: View {
+
+    public struct Item {
+
+        public let sourceURL: URL
+        public let url: URL
+
+    }
 
     @StateObject var model: LibraryModel
 
@@ -50,7 +57,8 @@ public struct SoftwareIndexView: View {
         delegate = nil
     }
 
-    public init(filter: @escaping (Release) -> Bool = { _ in true }, completion: @escaping (URL?) -> Void) {
+    public init(filter: @escaping (Release) -> Bool = { _ in true },
+                completion: @escaping (SoftwareIndexView.Item?) -> Void) {
         let delegate = LibraryModelBlockDelegate(complete: completion)
         let libraryModel = LibraryModel(filter: filter)
         libraryModel.delegate = delegate


### PR DESCRIPTION
This should allow clients to track the origin of installed software.