### PR TITLE
fix: Correct window sizing on macOS

### DIFF
--- a/Sources/PsionSoftwareIndex/Views/PsionSoftwareIndexView.swift
+++ b/Sources/PsionSoftwareIndex/Views/PsionSoftwareIndexView.swift
@@ -72,7 +72,7 @@ public struct PsionSoftwareIndexView: View {
             ProgramsView()
                 .environmentObject(model)
         }
-        .frame(width: 600, height: 400)
+        .frame(minWidth: 800, maxWidth: .infinity, minHeight: 600)
 #else
         NavigationView {
             ProgramsView()


### PR DESCRIPTION
This includes a drive-by fix to rename 'SoftwareIndexview.swift' to 'PsionSoftwareIndexView.swift'.