### PR TITLE
fix: Use the new always-available direct download URLs

### DIFF
--- a/Sources/PsionSoftwareIndex/API/Release.swift
+++ b/Sources/PsionSoftwareIndex/API/Release.swift
@@ -30,6 +30,8 @@ public struct Release: Codable, Identifiable {
     public let kind: Kind
     public let name: String
     let icon: Image?
+    let filename: String
+    let sha256: String
     let reference: [ReferenceItem]
     public let tags: [String]
 
@@ -46,16 +48,8 @@ public struct Release: Codable, Identifiable {
             .joined(separator: " - ")
     }
 
-    public var hasDownload: Bool {
-        return reference.last?.url != nil
-    }
-
-    var filename: String {
-        return reference.last!.name.lastPathComponent
-    }
-
-    var downloadURL: URL? {
-        return reference.last?.url
+    var downloadURL: URL {
+        return URL(string: "https://software.psion.info/files/\(sha256)")!
     }
 
 }

--- a/Sources/PsionSoftwareIndex/Model/LibraryModel.swift
+++ b/Sources/PsionSoftwareIndex/Model/LibraryModel.swift
@@ -89,6 +89,8 @@ protocol LibraryModelDelegate: AnyObject {
                                            kind: release.kind,
                                            name: release.name,
                                            icon: release.icon,
+                                           filename: release.filename,
+                                           sha256: release.sha256,
                                            reference: release.reference,
                                            tags: release.tags)
                         }
@@ -132,12 +134,12 @@ protocol LibraryModelDelegate: AnyObject {
     func download(_ release: Release) {
         dispatchPrecondition(condition: .onQueue(.main))
 
-        // Ensure the item has a download URL and there there are no active downloads for that URL.
-        guard let downloadURL = release.downloadURL,
-              downloads[downloadURL] == nil
-        else {
+        // Ensure there are no active downloads for that URL.
+        guard downloads[release.downloadURL] == nil else {
             return
         }
+
+        let downloadURL = release.downloadURL
 
         // Create the download task.
         let downloadTask = URLSession.shared.downloadTask(with: downloadURL) { [weak self] url, response, error in

--- a/Sources/PsionSoftwareIndex/Views/ProgramView.swift
+++ b/Sources/PsionSoftwareIndex/Views/ProgramView.swift
@@ -66,13 +66,13 @@ struct ProgramView: View {
                                         .font(.footnote)
                                 }
                                 Spacer()
-                                if let downloadURL = item.downloadURL, let task = libraryModel.downloads[downloadURL] {
+                                if let task = libraryModel.downloads[item.downloadURL] {
                                     HStack {
                                         ProgressView(task.progress)
                                             .progressViewStyle(.unadornedCircular)
                                             .controlSize(.small)
                                         Button("Cancel") {
-                                            libraryModel.downloads[downloadURL]?.cancel()
+                                            libraryModel.downloads[item.downloadURL]?.cancel()
                                         }
                                     }
                                 } else {

--- a/Sources/PsionSoftwareIndex/Views/ProgramsView.swift
+++ b/Sources/PsionSoftwareIndex/Views/ProgramsView.swift
@@ -42,6 +42,7 @@ struct ProgramsView: View {
         }
         .searchable(text: $libraryModel.searchFilter)
         .navigationTitle("Psion Software Index")
+        .navigationSubtitle("\(libraryModel.filteredPrograms.count) Programs")
         .onAppear {
             libraryModel.start()
         }

--- a/Sources/PsionSoftwareIndex/Windows/PsionSoftwareIndexWindow.swift
+++ b/Sources/PsionSoftwareIndex/Windows/PsionSoftwareIndexWindow.swift
@@ -37,7 +37,7 @@ public struct PsionSoftwareIndexWindow: Scene {
     public var body: some Scene {
         Window("Psion Software Index", id: Self.id) {
             PsionSoftwareIndexView { release in
-                return release.kind == .installer && release.hasDownload
+                return release.kind == .installer
             } completion: { item in
                 guard let item else {
                     return


### PR DESCRIPTION
This change switches to the new direct download URLs. These are now available for all programs so clients should see more entries.